### PR TITLE
Read and write unlinked files with open handles

### DIFF
--- a/osxfuse.xcodeproj/project.pbxproj
+++ b/osxfuse.xcodeproj/project.pbxproj
@@ -225,7 +225,6 @@
 				TargetAttributes = {
 					4332BEA71D108F4000F84D51 = {
 						CreatedOnToolsVersion = 8.0;
-						DevelopmentTeam = M683GB7CPW;
 						ProvisioningStyle = Manual;
 					};
 				};
@@ -390,8 +389,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_WARN_DOCUMENTATION_COMMENTS = NO;
-				CODE_SIGN_IDENTITY = "Mac Developer";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Mac Developer";
+				CODE_SIGN_IDENTITY = "Developer ID";
 				DWARF_DSYM_FOLDER_PATH = "$(CONFIGURATION_BUILD_DIR)/Debug";
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				INFOPLIST_FILE = osxfuse/Info.plist;
@@ -405,7 +403,6 @@
 				OTHER_CODE_SIGN_FLAGS = "--identifier $(MODULE_NAME)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.osxfuse.osxfuse;
 				PRODUCT_NAME = "$(OSXFUSE_NAME)";
-				PROVISIONING_PROFILE = "";
 				"VALID_ARCHS[sdk=macosx10.10]" = x86_64;
 				"VALID_ARCHS[sdk=macosx10.11]" = x86_64;
 				"VALID_ARCHS[sdk=macosx10.12]" = x86_64;
@@ -422,8 +419,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_WARN_DOCUMENTATION_COMMENTS = NO;
-				CODE_SIGN_IDENTITY = "Mac Developer";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Mac Developer";
+				CODE_SIGN_IDENTITY = "Developer ID";
 				COPY_PHASE_STRIP = YES;
 				DEPLOYMENT_POSTPROCESSING = YES;
 				DWARF_DSYM_FOLDER_PATH = "$(CONFIGURATION_BUILD_DIR)/Debug";
@@ -440,7 +436,6 @@
 				OTHER_CODE_SIGN_FLAGS = "--identifier $(MODULE_NAME)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.osxfuse.osxfuse;
 				PRODUCT_NAME = "$(OSXFUSE_NAME)";
-				PROVISIONING_PROFILE = "";
 				SEPARATE_STRIP = YES;
 				STRIP_STYLE = "non-global";
 				"VALID_ARCHS[sdk=macosx10.10]" = x86_64;

--- a/osxfuse.xcodeproj/project.pbxproj
+++ b/osxfuse.xcodeproj/project.pbxproj
@@ -225,6 +225,7 @@
 				TargetAttributes = {
 					4332BEA71D108F4000F84D51 = {
 						CreatedOnToolsVersion = 8.0;
+						DevelopmentTeam = M683GB7CPW;
 						ProvisioningStyle = Manual;
 					};
 				};
@@ -389,7 +390,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_WARN_DOCUMENTATION_COMMENTS = NO;
-				CODE_SIGN_IDENTITY = "Developer ID";
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Mac Developer";
 				DWARF_DSYM_FOLDER_PATH = "$(CONFIGURATION_BUILD_DIR)/Debug";
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				INFOPLIST_FILE = osxfuse/Info.plist;
@@ -403,6 +405,7 @@
 				OTHER_CODE_SIGN_FLAGS = "--identifier $(MODULE_NAME)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.osxfuse.osxfuse;
 				PRODUCT_NAME = "$(OSXFUSE_NAME)";
+				PROVISIONING_PROFILE = "";
 				"VALID_ARCHS[sdk=macosx10.10]" = x86_64;
 				"VALID_ARCHS[sdk=macosx10.11]" = x86_64;
 				"VALID_ARCHS[sdk=macosx10.12]" = x86_64;
@@ -419,7 +422,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_WARN_DOCUMENTATION_COMMENTS = NO;
-				CODE_SIGN_IDENTITY = "Developer ID";
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Mac Developer";
 				COPY_PHASE_STRIP = YES;
 				DEPLOYMENT_POSTPROCESSING = YES;
 				DWARF_DSYM_FOLDER_PATH = "$(CONFIGURATION_BUILD_DIR)/Debug";
@@ -436,6 +440,7 @@
 				OTHER_CODE_SIGN_FLAGS = "--identifier $(MODULE_NAME)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.osxfuse.osxfuse;
 				PRODUCT_NAME = "$(OSXFUSE_NAME)";
+				PROVISIONING_PROFILE = "";
 				SEPARATE_STRIP = YES;
 				STRIP_STYLE = "non-global";
 				"VALID_ARCHS[sdk=macosx10.10]" = x86_64;

--- a/osxfuse/fuse_vnops.c
+++ b/osxfuse/fuse_vnops.c
@@ -2602,8 +2602,6 @@ FUSE_VNOP_EXPORT
 int
 fuse_vnop_read(struct vnop_read_args *ap)
 {
-    IOLog("osxfuse: Starting fuse_vnop_read\n");
-
     vnode_t       vp      = ap->a_vp;
     uio_t         uio     = ap->a_uio;
     int           ioflag  = ap->a_ioflag;
@@ -2632,20 +2630,16 @@ fuse_vnop_read(struct vnop_read_args *ap)
 
     if (fuse_isdeadfs(vp) && !vnode_isinuse(vp, 0)) {
         if (!vnode_ischr(vp)) {
-            IOLog("osxfuse: Returning ENXIO because !vnode_ischr\n");
             return ENXIO;
         } else {
-            IOLog("osxfuse: Return 0 [2]\n");
             return 0;
         }
     }
 
     if (!vnode_isreg(vp)) {
         if (vnode_isdir(vp)) {
-            IOLog("osxfuse: Return EISDIR [3]\n");
             return EISDIR;
         } else {
-            IOLog("osxfuse: Return EPERM [4]\n");
             return EPERM;
         }
     }
@@ -2658,19 +2652,16 @@ fuse_vnop_read(struct vnop_read_args *ap)
 
     orig_resid = uio_resid(uio);
     if (orig_resid == 0) {
-        IOLog("osxfuse: Return 0 [5]\n");
         return 0;
     }
 
     orig_offset = uio_offset(uio);
     if (orig_offset < 0) {
-        IOLog("osxfuse: Return EINVAL [6]\n");
         return EINVAL;
     }
 
     fvdat = VTOFUD(vp);
     if (!fvdat) {
-        IOLog("osxfuse: Return EINVAL [7]\n");
         return EINVAL;
     }
 
@@ -2691,7 +2682,6 @@ fuse_vnop_read(struct vnop_read_args *ap)
 #if M_OSXFUSE_ENABLE_BIG_LOCK
         fuse_biglock_lock(data->biglock);
 #endif
-        IOLog("osxfuse: Return res(%d) [8]\n", res);
         return res;
     }
 
@@ -2708,7 +2698,6 @@ fuse_vnop_read(struct vnop_read_args *ap)
             fufh_type = FUFH_RDWR;
             fufh = &(fvdat->fufh[fufh_type]);
             if (!FUFH_IS_VALID(fufh)) {
-                IOLog("osxfuse: !FUFH_IS_VALID(fufh = %llu)\n", fufh->fh_id);
                 fufh = NULL;
             } else {
                 /* Read falling back to FUFH_RDWR. */
@@ -2717,7 +2706,6 @@ fuse_vnop_read(struct vnop_read_args *ap)
 
         if (!fufh) {
             /* Failing direct I/O because of no fufh. */
-            IOLog("osxfuse: Return EIO [9]\n");
             return EIO;
         } else {
             /* Using existing fufh of type fufh_type. */
@@ -2764,7 +2752,6 @@ fuse_vnop_read(struct vnop_read_args *ap)
 
     } /* direct_io */
 
-    IOLog("osxfuse: Return 0 or err(%d) [10]\n", err);
     return ((err == -1) ? 0 : err);
 }
 


### PR DESCRIPTION
This allows files that have open handles, but have been unlinked after the handle was opened to still be read and written to without errors. To make this possible, the following changes are made:

* If the user-space daemon implements `fgetattr`, it will now be called for any unlinked files that have an open handle.
* If a `read` call comes in, the kext will allow it to proceed if it realizes the vnode is in use (aka there's at least one open handle).
* Same thing for a `write` call.